### PR TITLE
Fix py.typed omission

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("readme.md", "r") as fh:
         url="https://github.com/superbird11/ranges",
         packages=setuptools.find_packages(),
         package_data={
-            "ranges": ["py.types"]
+            "ranges": ["py.typed"]
         },
         classifiers=[
             "Programming Language :: Python :: 3",


### PR DESCRIPTION
@Superbird11 This issue was closed so I think @jheiss's additional comments in https://github.com/Superbird11/ranges/issues/20 were buried.

The `py.typed` file isn't properly included because of a typo, this fixes that.

I tested this by installing my fork of `python-ranges` as an editable package in an existing project and the types were properly picked up by mypy.